### PR TITLE
Fix: Error not always reporting

### DIFF
--- a/khi_hardware/src/khi_publisher.cpp
+++ b/khi_hardware/src/khi_publisher.cpp
@@ -56,13 +56,13 @@ void KhiPublisher::start(const KhiDriver & driver)
 
 void KhiPublisher::report_error(const KhiDriver & driver)
 {
-  // Determine if error repoting should be re-enabled.
-  if (should_stop_error_reporting_ && driver.is_error())
-  {
-    std::vector<int> error_codes;
-    std::vector<std::string> error_msgs;
-    driver.get_error_info(error_codes, error_msgs);
+  std::vector<int> error_codes;
+  std::vector<std::string> error_msgs;
+  driver.get_error_info(error_codes, error_msgs);
 
+  // Determine if error repoting should be re-enabled.
+  if (should_stop_error_reporting_)
+  {
     if (error_codes.size() != old_error_codes_.size())
     {
       should_stop_error_reporting_ = false;
@@ -76,39 +76,29 @@ void KhiPublisher::report_error(const KhiDriver & driver)
           should_stop_error_reporting_ = false;
         }
       }
-    }
+    } 
 
-    if (!should_stop_error_reporting_)
-    {
-      old_error_codes_.resize(0);
-    }
+    old_error_codes_ = error_codes;
   }
 
-  // Determine if error repoting should be re-enabled.
+  // Report error if error reporting is enabled.
   if (!should_stop_error_reporting_)
   {
-    khi_msgs::msg::ErrorInfo error_info;
-    driver.get_error_info(error_info.error_codes, error_info.error_msgs);
-    if (error_info.error_codes.empty())
+    if (!error_codes.empty())
     {
-      return;
+      // Get the current time.
+      khi_msgs::msg::ErrorInfo error_info;
+      rclcpp::Clock ros_clock(RCL_ROS_TIME);
+      const rclcpp::Time now = ros_clock.now();
+      error_info.stamp = now;
+      error_info.error_codes = error_codes;
+      error_info.error_msgs = error_msgs;
+      
+      error_info_publisher_->publish(error_info);
     }
-
-    // Get the current time.
-    rclcpp::Clock ros_clock(RCL_ROS_TIME);
-    const rclcpp::Time now = ros_clock.now();
-    const auto current_time = static_cast<std::time_t>(now.seconds());
-    std::tm time_info{};
-    localtime_r(&current_time, &time_info);
-    std::ostringstream oss;
-    oss << std::put_time(&time_info, "%Y-%m-%d %H:%M:%S");
-    error_info.time = oss.str();
-
-    error_info_publisher_->publish(error_info);
 
     // Prevent repeated Publishing of error information.
     should_stop_error_reporting_ = true;
-    old_error_codes_ = error_info.error_codes;
   }
 }
 

--- a/khi_msgs/CMakeLists.txt
+++ b/khi_msgs/CMakeLists.txt
@@ -18,6 +18,7 @@ endif()
 # find dependencies
 find_package(ament_cmake REQUIRED)
 find_package(rosidl_default_generators REQUIRED)
+find_package(builtin_interfaces REQUIRED)
 
 set(msg_files
   "msg/ErrorInfo.msg"
@@ -35,6 +36,8 @@ set(srv_files
 rosidl_generate_interfaces(${PROJECT_NAME}
   ${msg_files}
   ${srv_files}
+  DEPENDENCIES
+    builtin_interfaces
 )
 ament_export_dependencies(rosidl_default_runtime)
 

--- a/khi_msgs/msg/ErrorInfo.msg
+++ b/khi_msgs/msg/ErrorInfo.msg
@@ -1,6 +1,8 @@
 # Example
 #   >ros2 topic echo /khi_controller0/khi_publisher/error_info
-#   time: '2024-06-26 18:13:49'
+#   stamp:
+#     sec: 1621886400 # seconds since epoch
+#     nanosec: 500000000 # nanoseconds into the second
 #   error_codes:
 #   - -31135
 #   - -21080
@@ -10,8 +12,7 @@
 #
 #   Note: The '0' in khi_controller0 changes according to controller_no specified in khi_bringup.launch.py.
 
-# The date and time of the error occurence (year-month-day hour:minute:second) will be stored.
-string time
+builtin_interfaces/Time stamp
 
 # -1xxxx : Operation Error
 # -2xxxx : Mechanical/Control Warning


### PR DESCRIPTION
### Issue

`old_error_codes_` do not get updated when there is no error. If we receive an error code (e.g. -31135), it clears, and then we receive it again -> the second time does not publish the error.

### Changes

- Always update the `old_error_codes_` with the current error codes (even if there is no error) + continue to only publish the error when there is a new error
- Change the `ErrorInfo.msg` to use the ROS clock instead of a time string so that it's easier to deal with different time zones